### PR TITLE
Fix Sonar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ cache:
 jobs:
   include:
     - stage: build
-      jdk: openjdk14
+      jdk: openjdk13
       before_script:
         - java -Xmx32m -version
         - git fetch --unshallow


### PR DESCRIPTION
A while ago the build JDK was set to 14 as Travis' Java 11 is old and was throwing an NPE deep down in the compiler during the build. Unfortunately the Sonar plugin does not support Java 14 yet so we don't see the full test coverage for example.

This PR attempts to find a solution that makes both the build and Sonar work.