### PR TITLE
Add aliases for tag command help

### DIFF
--- a/src/main/java/space/npstr/wolfia/commands/util/TagCommand.java
+++ b/src/main/java/space/npstr/wolfia/commands/util/TagCommand.java
@@ -68,8 +68,8 @@ public class TagCommand implements BaseCommand, PublicCommand {
     public String help() {
         return invocation() + " add/remove/[your message]"
                 + "\n#Add or remove yourself from the taglist, or tag members who signed up for the taglist with an optional message. Examples:"
-                + "\n  " + invocation() + " add"
-                + "\n  " + invocation() + " remove"
+                + "\n  " + invocation() + " add (or +)"
+                + "\n  " + invocation() + " remove (or -)"
                 + "\n  " + invocation() + " WANT SUM GAME?";
     }
 


### PR DESCRIPTION
Noticed that the help info didn't have the aliases, so I added them.